### PR TITLE
Slow users down trying to jump ahead [fixes #6]

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,8 @@ class HomeController < ApplicationController
   
   def index
     if user_signed_in?
+      # Refuse to show the dashboard to people who haven't completed step 1
+      return redirect_to(profile_index_path) if !current_user.basic_names_complete?
       render 'user_home'
     else
       render 'anon_home'

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -49,6 +49,12 @@ class ProfileController < ApplicationController
     end
   end
   
+  # Users must complete the first step to continue
+  def stuck_on_first_step?
+    (@user.full_name.blank? || @user.personal_name.blank?)
+  end
+  helper_method :stuck_on_first_step?
+  
   private
   
   def set_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,9 +48,15 @@ class User < ApplicationRecord
     public_send(pronunciation_of)
   end
   
+  # To be able to freely move around the profile, you must have entered a full
+  # name and a personal name
+  def basic_names_complete?
+    full_name.present? && personal_name.present?
+  end
+  
   # To have a complete profile you must have entered a full name,
   # a personal name and at least one pronoun
   def profile_complete?
-    full_name.present? && personal_name.present? && pronoun_sets.any? && slug.present?
+    basic_names_complete? && pronoun_sets.any? && slug.present?
   end
 end

--- a/app/views/profile/_header.html.haml
+++ b/app/views/profile/_header.html.haml
@@ -1,12 +1,19 @@
 %section.section
   .container
-    = f.button :button, value: 'finish', class: 'is-outlined is-pulled-right' do
-      %span= t('.save_and_exit')
-      %span.icon
-        %i.mdi.mdi-close
+    - if @user.basic_names_complete?
+      = f.button :button, value: 'finish', class: 'is-outlined is-pulled-right' do
+        %span= t('.save_and_exit')
+        %span.icon
+          %i.mdi.mdi-close
     %ul.steps.has-content-centered.is-small
       - wizard_steps.each.with_index do |each_step|
-        %li.steps-segment{class: ('is-active' if each_step == step)}
-          = link_to '', wizard_path(each_step), class: 'steps-marker'
-          .steps-content
-            %p.is-size-6= t("profile.#{each_step}.title")
+        - if @user.basic_names_complete?
+          %li.steps-segment{class: ('is-active' if each_step == step)}
+            = link_to '', wizard_path(each_step), class: 'steps-marker'
+            .steps-content
+              %p.is-size-6= t("profile.#{each_step}.title")
+        - else
+          %li.steps-segment.is-dashed{class: ('is-active' if each_step == step)}
+            .steps-marker
+            .steps-content
+              %p.is-size-6= t("profile.#{each_step}.title")

--- a/features/signup_and_edit_profile.feature
+++ b/features/signup_and_edit_profile.feature
@@ -7,6 +7,26 @@ Scenario: Sign up takes user to profile editor
   And I submit the form
   Then I should be on the first page of the profile editor
   And my account should have been created on the backend
+
+Scenario: Cannot leave first page until it's completed
+  Given I am signed in as a user with no profile
+  When I try to go the home page
+  Then I should be redirected back to the first page of the profile editor
+  And I should not see links to the other sections
+  And I should not see a save and exit button
+
+Scenario: Can see dashboard if first page has been completed
+  Given I am signed in as a user with no profile
+  And I have filled out my personal name and full name elsewhere
+  When I try to go the home page
+  Then I should see the dashboard
+  
+Scenario: Can leave first page if first page has been completed
+  Given I am signed in as a user with no profile
+  And I have filled out my personal name and full name elsewhere
+  When I go to the profile editor
+  Then I should see links to the other sections
+  And I should see a save and exit button
   
 @javascript
 Scenario: Complete profile editing

--- a/features/steps/common_steps/auth.rb
+++ b/features/steps/common_steps/auth.rb
@@ -17,7 +17,7 @@ module CommonSteps
     step 'I am signed in as a user with no profile' do
       sign_in_as create(:user, :test)
     end
-
+    
     def sign_in_as(user)
       visit new_user_session_path
       fill_in 'Your email address', with: user.email

--- a/features/steps/signup_and_edit_profile.rb
+++ b/features/steps/signup_and_edit_profile.rb
@@ -208,4 +208,40 @@ class Spinach::Features::SignupAndEditProfile < Spinach::FeatureSteps
     expect(page).to have_content("Audrey is pronounced")
     expect(page).to have_content("Audio clip of 'Audrey'")
   end
+  
+  step 'I try to go the home page' do
+    visit '/'
+  end
+
+  step 'I should be redirected back to the first page of the profile editor' do
+    expect(page).to have_css('.box.profile-form.is-personal-name')
+  end
+
+  step 'I should not see links to the other sections' do
+    expect(page).not_to have_css('a.steps-marker[href]')
+  end
+
+  step 'I should not see a save and exit button' do
+    expect(page).not_to have_css('button', text: 'Save and exit')
+  end
+
+  step 'I have filled out my personal name and full name elsewhere' do
+    test_user.update(full_name: 'Harold Smith', personal_name: 'Harold')
+  end
+
+  step 'I should see the dashboard' do
+    expect(page).to have_css('.title', text: 'Your name dashboard')
+  end
+
+  step 'I go to the profile editor' do
+    visit '/profile/personal_name'
+  end
+
+  step 'I should see links to the other sections' do
+    expect(page).to have_css('a.steps-marker[href]')
+  end
+
+  step 'I should see a save and exit button' do
+    expect(page).to have_css('button', text: 'Save and exit')
+  end
 end


### PR DESCRIPTION
This fixes #6 by forcing users to complete the first page of the profile before they can go to the dashboard or any of the other pages on the profile builder. Hopefully a nicer user experience for users!